### PR TITLE
Using shared memory objects in postprocessing

### DIFF
--- a/transformato/analysis.py
+++ b/transformato/analysis.py
@@ -204,8 +204,6 @@ class FreeEnergyCalculator(object):
         Calculates the potential energy with the correct periodic boundary conditions.
         """
         if env != "vacuum":
-            print("UNITCELL:")
-            print(unitcell_vectors[ts])
             simulation.context.setPeriodicBoxVectors(
                 unitcell_vectors[ts][0],
                 unitcell_vectors[ts][1],

--- a/transformato/analysis.py
+++ b/transformato/analysis.py
@@ -19,7 +19,7 @@ from simtk.openmm import Platform, XmlSerializer
 from simtk.openmm.app import CharmmPsfFile, Simulation
 from tqdm import tqdm
 
-from transformato.constants import NUM_PROC, temperature
+from transformato.constants import temperature
 from transformato.utils import get_structure_name
 
 logger = logging.getLogger(__name__)
@@ -397,6 +397,7 @@ class FreeEnergyCalculator(object):
         save_results: bool,
         engine: str,
     ):
+        from transformato.constants import NUM_PROC
 
         #########################################################
         #########################################################

--- a/transformato/constants.py
+++ b/transformato/constants.py
@@ -23,12 +23,12 @@ def initialize_NUM_PROC(n_proc):
         print(msg)
 
 
-def check_platform(configuration: dict):
+def change_platform(configuration: dict, change_to="CPU"):
 
-    if platform.upper() == "GPU":
+    if change_to.upper() == "GPU":
         configuration["simulation"]["GPU"] = True
         print("Setting platform to GPU")
-    elif platform.upper() == "CPU":
+    elif change_to.upper() == "CPU":
         configuration["simulation"]["GPU"] = False
         print("Setting platform to CPU")
     else:

--- a/transformato/schrodinger_systems.py
+++ b/transformato/schrodinger_systems.py
@@ -5,7 +5,7 @@ from transformato.mutate import ProposeMutationRoute
 from transformato.state import IntermediateStateFactory
 from transformato.system import SystemStructure
 from transformato.utils import load_config_yaml
-from transformato.constants import check_platform
+from transformato.constants import change_platform
 
 
 def cdk2_withoutHeavyAtom(conf_path: str, input_dir: str, output_dir: str):
@@ -16,24 +16,27 @@ def cdk2_withoutHeavyAtom(conf_path: str, input_dir: str, output_dir: str):
     s1 = SystemStructure(configuration, "structure1")
     s2 = SystemStructure(configuration, "structure2")
     s1_to_s2 = ProposeMutationRoute(s1, s2)
-    #s1_to_s2.calculate_common_core()
+    # s1_to_s2.calculate_common_core()
     s1_to_s2.propose_common_core()
-    connected_dummy_regions_cc1=[set(s1_to_s2.get_idx_not_in_common_core_for_mol1())]
-    connected_dummy_regions_cc2=[set(s1_to_s2.get_idx_not_in_common_core_for_mol2())]
+    connected_dummy_regions_cc1 = [set(s1_to_s2.get_idx_not_in_common_core_for_mol1())]
+    connected_dummy_regions_cc2 = [set(s1_to_s2.get_idx_not_in_common_core_for_mol2())]
 
-    s1_to_s2.finish_common_core(connected_dummy_regions_cc1=connected_dummy_regions_cc1, connected_dummy_regions_cc2=connected_dummy_regions_cc2)
+    s1_to_s2.finish_common_core(
+        connected_dummy_regions_cc1=connected_dummy_regions_cc1,
+        connected_dummy_regions_cc2=connected_dummy_regions_cc2,
+    )
 
     ###############################
     ####### Structure 1    ########
     ###############################
-    
+
     # generate the mutation list for the original
     mutation_list = s1_to_s2.generate_mutations_to_common_core_for_mol1()
     print(mutation_list.keys())
     output_files = []
     i = IntermediateStateFactory(
-    system=s1,
-    configuration=configuration,
+        system=s1,
+        configuration=configuration,
     )
 
     # write endpoint mutation
@@ -44,43 +47,42 @@ def cdk2_withoutHeavyAtom(conf_path: str, input_dir: str, output_dir: str):
     # turn off charges
     charges = mutation_list["charge"]
     nr_of_mutation_steps_charge = (
-    1  # defines the number of mutation steps for charge mutation
+        1  # defines the number of mutation steps for charge mutation
     )
     for lambda_value in np.linspace(1, 0, nr_of_mutation_steps_charge + 1)[1:]:
         output_file_base, intst = i.write_state(
-        mutation_conf=charges,
-        lambda_value_electrostatic=lambda_value,
-        intst_nr=intst,
-    )
+            mutation_conf=charges,
+            lambda_value_electrostatic=lambda_value,
+            intst_nr=intst,
+        )
     output_files.append(output_file_base)
 
     # Turn off hydrogens
     hydrogen_lj_mutations = mutation_list["hydrogen-lj"]
     output_file_base, intst = i.write_state(
-    mutation_conf=hydrogen_lj_mutations,
-    lambda_value_vdw=0.0,
-    intst_nr=intst,
+        mutation_conf=hydrogen_lj_mutations,
+        lambda_value_vdw=0.0,
+        intst_nr=intst,
     )
     output_files.append(output_file_base)
 
-
     # generate terminal lj
     output_file_base, intst = i.write_state(
-    mutation_conf=mutation_list["default-lj"],
-    lambda_value_vdw=0.0,
-    intst_nr=intst,
+        mutation_conf=mutation_list["default-lj"],
+        lambda_value_vdw=0.0,
+        intst_nr=intst,
     )
     output_files.append(output_file_base)
 
     # change bonded parameters on common core
     m = mutation_list["transform"]
     for lambda_value in np.linspace(0.75, 0, 2):
-    # interpolate between parameters
+        # interpolate between parameters
         output_file_base, intst = i.write_state(
-        mutation_conf=m,
-        common_core_transformation=lambda_value,
-        intst_nr=intst,
-    )
+            mutation_conf=m,
+            common_core_transformation=lambda_value,
+            intst_nr=intst,
+        )
     output_files.append(output_file_base)
 
     ###############################
@@ -90,8 +92,8 @@ def cdk2_withoutHeavyAtom(conf_path: str, input_dir: str, output_dir: str):
     mutation_list = s1_to_s2.generate_mutations_to_common_core_for_mol2()
 
     i = IntermediateStateFactory(
-    system=s2,
-    configuration=configuration,
+        system=s2,
+        configuration=configuration,
     )
 
     output_files = []
@@ -102,30 +104,30 @@ def cdk2_withoutHeavyAtom(conf_path: str, input_dir: str, output_dir: str):
     # turn off charges
     charges = mutation_list["charge"]
     nr_of_mutation_steps_charge = (
-    1  # defines the number of mutation steps for charge mutation
+        1  # defines the number of mutation steps for charge mutation
     )
     for lambda_value in np.linspace(1, 0, nr_of_mutation_steps_charge + 1)[1:]:
         output_file_base, intst = i.write_state(
-        mutation_conf=charges,
-        lambda_value_electrostatic=lambda_value,
-        intst_nr=intst,
-    )
+            mutation_conf=charges,
+            lambda_value_electrostatic=lambda_value,
+            intst_nr=intst,
+        )
     output_files.append(output_file_base)
 
     # Turn off hydrogens
     hydrogen_lj_mutations = mutation_list["hydrogen-lj"]
     output_file_base, intst = i.write_state(
-    mutation_conf=hydrogen_lj_mutations,
-    lambda_value_vdw=0.0,
-    intst_nr=intst,
+        mutation_conf=hydrogen_lj_mutations,
+        lambda_value_vdw=0.0,
+        intst_nr=intst,
     )
     output_files.append(output_file_base)
     d = transformato.utils.map_lj_mutations_to_atom_idx(mutation_list["lj"])
 
     # generate terminal lj
     output_file_base, intst = i.write_state(
-    mutation_conf=mutation_list["default-lj"],
-    lambda_value_vdw=0.0,
-    intst_nr=intst,
+        mutation_conf=mutation_list["default-lj"],
+        lambda_value_vdw=0.0,
+        intst_nr=intst,
     )
     output_files.append(output_file_base)

--- a/transformato/state.py
+++ b/transformato/state.py
@@ -224,7 +224,6 @@ with open(file_name + '_system.xml','w') as outfile:
                 charmm_simulation_submit_script_target,
             )
 
-
             for env in self.system.envs:
                 if env == "waterbox":
                     # write charmm production scripte
@@ -280,7 +279,6 @@ with open(file_name + '_system.xml','w') as outfile:
                     # )
                 else:
                     raise NotImplementedError()
-        
 
         else:
             pass
@@ -411,7 +409,7 @@ with open(file_name + '_system.xml','w') as outfile:
         shutil.copyfile(omm_simulation_script_source, omm_simulation_script_target)
         # add serialization
         self._add_serializer(omm_simulation_script_target)
-        self._check_platform(omm_simulation_script_target)
+        self._change_platform(omm_simulation_script_target)
         self._check_switching_function(omm_simulation_script_target)
 
         # continue with vacuum
@@ -423,7 +421,7 @@ with open(file_name + '_system.xml','w') as outfile:
         )
         shutil.copyfile(omm_simulation_script_source, omm_simulation_script_target)
         self._add_serializer(omm_simulation_script_target)
-        self._check_platform(omm_simulation_script_target)
+        self._change_platform(omm_simulation_script_target)
 
     def _check_switching_function(self, file):
         """
@@ -443,7 +441,7 @@ with open(file_name + '_system.xml','w') as outfile:
                 f"Other switching functino called: {self.vdw_switch}."
             )
 
-    def _check_platform(self, file):
+    def _change_platform(self, file):
         # changin input script
         f = open(file, "r")
         g = open(f"{file}_tmp", "w+")

--- a/transformato/tests/mp_dev.py
+++ b/transformato/tests/mp_dev.py
@@ -8,7 +8,7 @@ import multiprocessing as mp
 import numpy as np
 from itertools import repeat
 from multiprocessing import shared_memory
-initialize_NUM_PROC(6)
+
 
 def postprocessing(
     configuration: dict,
@@ -71,14 +71,16 @@ def calculate_rbfe_mp():
     )
 
 
-  
 def procft(snapshots):
     print(snapshots.n_frames)
     for i in range(snapshots.n_frames):
-        j=i*i
-        print(j,)
+        j = i * i
+        print(
+            j,
+        )
         sleep(1)
     return j
+
 
 def procsh(shr_name, dims, i):
     print(shr_name)
@@ -88,22 +90,25 @@ def procsh(shr_name, dims, i):
     np_array = np.ndarray(dims, dtype=np.float32, buffer=existing_shm.buf)
 
     for i in range(len(np_array))[:50]:
-        j=i*i
-        print(j,)
+        j = i * i
+        print(
+            j,
+        )
         sleep(1)
     existing_shm.close()
 
+
 def create_data():
 
-    name="2OJ9-original"
+    name = "2OJ9-original"
     conf = "config/test-2oj9-tautomer-pair-rbfe.yaml"
     configuration = load_config_yaml(
         config=conf, input_dir="../../data/", output_dir="../../data"
     )  # NOTE: for preprocessing input_dir is the output dir
-    
+
     f = FreeEnergyCalculator(configuration, name)
     f.load_trajs(nr_of_max_snapshots=1_000)
-    snapshots = f.snapshots['complex']
+    snapshots = f.snapshots["complex"]
     print(snapshots.n_frames)
     xyz = np.asarray(snapshots.xyz)
     dims = xyz.shape
@@ -114,26 +119,28 @@ def create_data():
     shm_xyz[:] = xyz[:]
     return shm, shm_xyz, dims
 
-def load_traj_span_mp(shm, shm_xyz, dims):
 
+def load_traj_span_mp(shm, shm_xyz, dims):
 
     ctx = mp.get_context("spawn")
     pool = ctx.Pool(processes=4)
-    #pool.map(proct, [i for i in range(snapshots.n_frames)])
+    # pool.map(proct, [i for i in range(snapshots.n_frames)])
 
-    #pool.map(procf, repeat(snapshots))
-    #map(procf, zip(repeat(snapshots), [i for i in range(7)]))
-    #r = map(procf, (snapshots, 1))
-    #print(list(r))
-    #r = map(procft, [snapshots])
-    #print(list(r))
-    #pool.map(procft, [snapshots,snapshots,snapshots,snapshots])
+    # pool.map(procf, repeat(snapshots))
+    # map(procf, zip(repeat(snapshots), [i for i in range(7)]))
+    # r = map(procf, (snapshots, 1))
+    # print(list(r))
+    # r = map(procft, [snapshots])
+    # print(list(r))
+    # pool.map(procft, [snapshots,snapshots,snapshots,snapshots])
     pool.starmap(procsh, zip(repeat(shm.name), repeat(dims), [i for i in range(4)]))
-    
+
+
 if __name__ == "__main__":
+    initialize_NUM_PROC(1)
     # calculate_rsfe_mp()
-    #calculate_rbfe_mp()
-    shm, shm_xyz, dims = create_data()
-    load_traj_span_mp(shm, shm_xyz, dims)
-    shm.close()
-    shm.unlink()
+    calculate_rbfe_mp()
+    # shm, shm_xyz, dims = create_data()
+    # load_traj_span_mp(shm, shm_xyz, dims)
+    # shm.close()
+    # shm.unlink()

--- a/transformato/tests/mp_dev.py
+++ b/transformato/tests/mp_dev.py
@@ -66,7 +66,34 @@ def calculate_rbfe_mp():
         configuration, name="2OJ9-original", engine="openMM", max_snapshots=1000
     )
 
+def load_traj_span_mp():
+    
+    def proc(snapshots):
+        print(len(snapshots))
+        
+    
+    import _multiprocessing as mp
+    
+    name="2OJ9-original"
+    conf = "config/test-2oj9-tautomer-pair-rbfe.yaml"
+    configuration = load_config_yaml(
+        config=conf, input_dir="../../data/", output_dir="../../data"
+    )  # NOTE: for preprocessing input_dir is the output dir
+    
+    f = FreeEnergyCalculator(configuration, name)
+    f.load_trajs(nr_of_max_snapshots=1_000)
+    snapshots = f.snapshots
+    
+    #xyz = np.asarray(snapshots.xyz)
+    #shm = shared_memory.SharedMemory(create=True, size=xyz.nbytes)
+    #shm_xyz = np.ndarray(xyz.shape, dtype=xyz.dtype, buffer=shm.buf)
+    #shm_xyz[:] = xyz[:]
+    
+    ctx = mp.get_context("fork")
+    pool = ctx.Pool(processes=4)
+    pool.map(proc, snapshots)
+
 
 if __name__ == "__main__":
     # calculate_rsfe_mp()
-    calculate_rbfe_mp()
+    #calculate_rbfe_mp()

--- a/transformato/tests/test_misc.py
+++ b/transformato/tests/test_misc.py
@@ -45,7 +45,7 @@ def test_convert_to_kT():
 
 
 def test_change_platform():
-    from ..constants import check_platform, platform
+    from ..constants import change_platform, platform
     from ..utils import load_config_yaml
 
     configuration = load_config_yaml(
@@ -54,7 +54,7 @@ def test_change_platform():
         output_dir=".",
     )
 
-    check_platform(configuration)
+    change_platform(configuration)
     print(configuration["simulation"]["GPU"])
     print(platform)
     if platform.upper() == "CPU":

--- a/transformato/tests/test_mutation.py
+++ b/transformato/tests/test_mutation.py
@@ -1818,9 +1818,9 @@ def setup_2OJ9_tautomer_pair_rsfe(
     configuration: dict, single_state=False, nr_of_bonded_windows: int = 4
 ):
     from ..mutate import mutate_pure_tautomers
-    from ..constants import check_platform
+    from ..constants import change_platform
 
-    check_platform(configuration)
+    change_platform(configuration)
 
     s1 = SystemStructure(configuration, "structure1")
     s2 = SystemStructure(configuration, "structure2")
@@ -1841,12 +1841,12 @@ def setup_2OJ9_tautomer_pair_rsfe(
 
 
 def setup_2OJ9_tautomer_pair_rbfe(
-    configuration: dict, single_state:bool=False, nr_of_bonded_windows: int = 4
+    configuration: dict, single_state: bool = False, nr_of_bonded_windows: int = 4
 ):
     from ..mutate import mutate_pure_tautomers
-    from ..constants import check_platform
+    from ..constants import change_platform
 
-    check_platform(configuration)
+    change_platform(configuration)
 
     s1 = SystemStructure(configuration, "structure1")
     s2 = SystemStructure(configuration, "structure2")
@@ -1870,12 +1870,12 @@ def setup_acetylacetone_tautomer_pair(
     configuration: dict, single_state=False, nr_of_bonded_windows=4
 ):
     from ..mutate import mutate_pure_tautomers
-    from ..constants import check_platform
+    from ..constants import change_platform
 
     conf = "transformato/tests/config/test-acetylacetone-tautomer-rsfe.yaml"
     configuration = load_config_yaml(config=conf, input_dir="data/", output_dir=".")
 
-    check_platform(configuration)
+    change_platform(configuration)
 
     s1 = SystemStructure(configuration, "structure1")
     s2 = SystemStructure(configuration, "structure2")

--- a/transformato/tests/test_postprocessing.py
+++ b/transformato/tests/test_postprocessing.py
@@ -8,6 +8,7 @@ import numpy as np
 import pytest
 import logging
 from ..constants import initialize_NUM_PROC
+from transformato.constants import check_platform
 
 # read in specific topology with parameters
 from transformato import (
@@ -216,6 +217,7 @@ def test_2oj9_calculate_rsfe_with_openMM_mp(caplog):
     configuration = load_config_yaml(
         config=conf, input_dir="data/", output_dir="data"
     )  # NOTE: for preprocessing input_dir is the output dir
+    check_platform(configuration)
 
     # 2OJ9-original to tautomer common core
     ddG_openMM, dddG, f_openMM = postprocessing(

--- a/transformato/tests/test_postprocessing.py
+++ b/transformato/tests/test_postprocessing.py
@@ -8,7 +8,7 @@ import numpy as np
 import pytest
 import logging
 from ..constants import initialize_NUM_PROC
-from transformato.constants import check_platform
+from transformato.constants import change_platform
 
 # read in specific topology with parameters
 from transformato import (
@@ -77,7 +77,7 @@ def test_compare_energies_2OJ9_original_vacuum(caplog):
     configuration = load_config_yaml(
         config=conf, input_dir="data/", output_dir="data"
     )  # NOTE: for preprocessing input_dir is the output dir
-
+    change_platform(configuration)
     f = FreeEnergyCalculator(configuration, "2OJ9-original")
     for idx, b in enumerate(output_files_t1):
         traj = md.load_dcd(
@@ -85,8 +85,8 @@ def test_compare_energies_2OJ9_original_vacuum(caplog):
             f"{b}/lig_in_{env}.psf",
         )
         traj.save_dcd(f"{base}/traj.dcd")
-        l_charmm = f._evaluated_e_on_all_snapshots_CHARMM(traj, idx + 1, env)
-        l_openMM = f._evaluated_e_on_all_snapshots_openMM(traj, idx + 1, env)
+        l_charmm = f._evaluate_e_on_all_snapshots_CHARMM(traj, idx + 1, env)
+        l_openMM = f._evaluate_e_on_all_snapshots_openMM_sp(traj, idx + 1, env)
 
         assert len(l_charmm) == len(l_openMM)
         s = abs(np.array(l_charmm) - np.array(l_openMM))
@@ -95,6 +95,57 @@ def test_compare_energies_2OJ9_original_vacuum(caplog):
         assert mae < 0.005
         for e_charmm, e_openMM in zip(l_charmm, l_openMM):
             assert np.isclose(e_charmm, e_openMM, rtol=0.2)
+
+
+@pytest.mark.system_2oj9
+def test_compare_energies_2OJ9_original_vacuum_mp(caplog):
+    caplog.set_level(logging.WARNING)
+    from transformato import FreeEnergyCalculator
+    import mdtraj as md
+    from multiprocessing import shared_memory
+    import multiprocessing as mp
+    from itertools import repeat, starmap
+
+    env = "vacuum"
+
+    base = "data/2OJ9-original-2OJ9-tautomer-rsfe/2OJ9-original/"
+    output_files_t1, _ = _set_output_files_2oj9_tautomer_pair()
+
+    conf = "transformato/tests/config/test-2oj9-tautomer-pair-rsfe.yaml"
+
+    configuration = load_config_yaml(
+        config=conf, input_dir="data/", output_dir="data"
+    )  # NOTE: for preprocessing input_dir is the output dir
+    change_platform(configuration)
+    f = FreeEnergyCalculator(configuration, "2OJ9-original")
+    for idx, b in enumerate(output_files_t1):
+        traj = md.load_dcd(
+            f"{b}/lig_in_{env}.dcd",
+            f"{b}/lig_in_{env}.psf",
+        )
+
+        xyz = np.asarray(traj.xyz)
+        shm = shared_memory.SharedMemory(create=True, size=xyz.nbytes)
+        shm_xyz = np.ndarray(xyz.shape, dtype=xyz.dtype, buffer=shm.buf)
+        shm_xyz[:] = xyz[:]
+        unitcell_lengths = traj.unitcell_lengths
+        unitcell_vectors = traj.unitcell_vectors
+
+        ctx = mp.get_context("spawn")
+        pool = ctx.Pool(processes=2)
+
+        l_openMM = pool.starmap(
+            f._evaluate_e_on_all_snapshots_openMM_mp,
+            zip(
+                repeat(shm.name),
+                [1],
+                repeat(env),
+                repeat(xyz.shape),
+                repeat(unitcell_lengths),
+                repeat(unitcell_vectors),
+            ),
+        )
+        print(l_openMM)
 
 
 @pytest.mark.system_2oj9
@@ -121,7 +172,7 @@ def test_compare_energies_2OJ9_original_waterbox(caplog):
             f"{b}/lig_in_{env}.psf",
         )
         traj.save_dcd(f"{base}/traj.dcd")
-        l_charmm = f._evaluated_e_on_all_snapshots_CHARMM(traj, idx + 1, env)
+        l_charmm = f._evaluate_e_on_all_snapshots_CHARMM(traj, idx + 1, env)
         l_openMM = f._evaluated_e_on_all_snapshots_openMM(traj, idx + 1, env)
 
         assert len(l_charmm) == len(l_openMM)
@@ -148,6 +199,7 @@ def test_compare_energies_2OJ9_tautomer_vacuum(caplog):
     configuration = load_config_yaml(
         config=conf, input_dir="data/", output_dir="data"
     )  # NOTE: for preprocessing input_dir is the output dir
+    change_platform(configuration)
 
     f = FreeEnergyCalculator(configuration, "2OJ9-tautomer")
     for idx, b in enumerate(output_files_t2):
@@ -156,8 +208,8 @@ def test_compare_energies_2OJ9_tautomer_vacuum(caplog):
             f"{b}/lig_in_{env}.psf",
         )
         traj.save_dcd(f"{base}/traj.dcd")
-        l_charmm = f._evaluated_e_on_all_snapshots_CHARMM(traj, idx + 1, env)
-        l_openMM = f._evaluated_e_on_all_snapshots_openMM(traj, idx + 1, env)
+        l_charmm = f._evaluate_e_on_all_snapshots_CHARMM(traj, idx + 1, env)
+        l_openMM = f._evaluate_e_on_all_snapshots_openMM_sp(traj, idx + 1, env)
 
         assert len(l_charmm) == len(l_openMM)
         s = abs(np.array(l_charmm) - np.array(l_openMM))
@@ -192,7 +244,7 @@ def test_compare_energies_2OJ9_tautomer_waterbox(caplog):
         )
         # traj = traj.center_coordinates()
         traj.save_dcd(f"{base}/traj.dcd", force_overwrite=True)
-        l_charmm = f._evaluated_e_on_all_snapshots_CHARMM(traj, idx + 1, env)
+        l_charmm = f._evaluate_e_on_all_snapshots_CHARMM(traj, idx + 1, env)
         l_openMM = f._evaluated_e_on_all_snapshots_openMM(traj, idx + 1, env)
         assert len(l_charmm) == len(l_openMM)
         s = abs(np.array(l_charmm) - np.array(l_openMM))
@@ -212,16 +264,19 @@ def test_compare_energies_2OJ9_tautomer_waterbox(caplog):
 def test_2oj9_calculate_rsfe_with_openMM_mp(caplog):
     caplog.set_level(logging.DEBUG)
 
-    initialize_NUM_PROC(4)
+    initialize_NUM_PROC(2)
     conf = "transformato/tests/config/test-2oj9-tautomer-pair-rsfe.yaml"
     configuration = load_config_yaml(
         config=conf, input_dir="data/", output_dir="data"
     )  # NOTE: for preprocessing input_dir is the output dir
-    check_platform(configuration)
+    change_platform(configuration)
 
     # 2OJ9-original to tautomer common core
     ddG_openMM, dddG, f_openMM = postprocessing(
-        configuration, name="2OJ9-original", engine="openMM", max_snapshots=600
+        configuration,
+        name="2OJ9-original",
+        engine="openMM",
+        max_snapshots=600,
     )
 
     assert np.isclose(ddG_openMM, 1.6614072591246014)
@@ -447,7 +502,7 @@ def test_compare_energies_acetylacetone_enol_vacuum(caplog):
             f"{b}/lig_in_{env}.psf",
         )
         traj.save_dcd(f"{base}/traj.dcd")
-        l_charmm = f._evaluated_e_on_all_snapshots_CHARMM(traj, idx + 1, env)
+        l_charmm = f._evaluate_e_on_all_snapshots_CHARMM(traj, idx + 1, env)
         l_openMM = f._evaluated_e_on_all_snapshots_openMM(traj, idx + 1, env)
 
         assert len(l_charmm) == len(l_openMM)
@@ -487,7 +542,7 @@ def test_compare_energies_acetylacetone_enol_waterbox(caplog):
             f"{b}/lig_in_{env}.psf",
         )
         traj.save_dcd(f"{base}/traj.dcd")
-        l_charmm = f._evaluated_e_on_all_snapshots_CHARMM(traj, idx + 1, env)
+        l_charmm = f._evaluate_e_on_all_snapshots_CHARMM(traj, idx + 1, env)
         l_openMM = f._evaluated_e_on_all_snapshots_openMM(traj, idx + 1, env)
 
         assert len(l_charmm) == len(l_openMM)
@@ -526,7 +581,7 @@ def test_compare_energies_acetylacetone_keto_vacuum(caplog):
             f"{b}/lig_in_{env}.psf",
         )
         traj.save_dcd(f"{base}/traj.dcd")
-        l_charmm = f._evaluated_e_on_all_snapshots_CHARMM(traj, idx + 1, env)
+        l_charmm = f._evaluate_e_on_all_snapshots_CHARMM(traj, idx + 1, env)
         l_openMM = f._evaluated_e_on_all_snapshots_openMM(traj, idx + 1, env)
 
         assert len(l_charmm) == len(l_openMM)
@@ -565,7 +620,7 @@ def test_compare_energies_acetylacetone_keto_waterbox(caplog):
             f"{b}/lig_in_{env}.psf",
         )
         traj.save_dcd(f"{base}/traj.dcd")
-        l_charmm = f._evaluated_e_on_all_snapshots_CHARMM(traj, idx + 1, env)
+        l_charmm = f._evaluate_e_on_all_snapshots_CHARMM(traj, idx + 1, env)
         l_openMM = f._evaluated_e_on_all_snapshots_openMM(traj, idx + 1, env)
 
         assert len(l_charmm) == len(l_openMM)
@@ -737,7 +792,7 @@ def test_compare_energies_methane_vacuum(caplog):
             f"{b}/lig_in_{env}.psf",
         )
         traj.save_dcd(f"{base}/traj.dcd")
-        l_charmm = f._evaluated_e_on_all_snapshots_CHARMM(traj, idx + 1, env)
+        l_charmm = f._evaluate_e_on_all_snapshots_CHARMM(traj, idx + 1, env)
         l_openMM = f._evaluated_e_on_all_snapshots_openMM(traj, idx + 1, env)
 
         assert len(l_charmm) == len(l_openMM)
@@ -774,7 +829,7 @@ def test_compare_energies_methane_waterbox(caplog):
             f"{b}/lig_in_{env}.psf",
         )
         traj.save_dcd(f"{base}/traj.dcd")
-        l_charmm = f._evaluated_e_on_all_snapshots_CHARMM(traj, idx + 1, env)
+        l_charmm = f._evaluate_e_on_all_snapshots_CHARMM(traj, idx + 1, env)
         l_openMM = f._evaluated_e_on_all_snapshots_openMM(traj, idx + 1, env)
 
         assert len(l_charmm) == len(l_openMM)
@@ -811,7 +866,7 @@ def test_compare_energies_toluene_vacuum(caplog):
             f"{b}/lig_in_{env}.psf",
         )
         traj.save_dcd(f"{base}/traj.dcd")
-        l_charmm = f._evaluated_e_on_all_snapshots_CHARMM(traj, idx + 1, env)
+        l_charmm = f._evaluate_e_on_all_snapshots_CHARMM(traj, idx + 1, env)
         l_openMM = f._evaluated_e_on_all_snapshots_openMM(traj, idx + 1, env)
 
         assert len(l_charmm) == len(l_openMM)
@@ -848,7 +903,7 @@ def test_compare_energies_toluene_waterbox(caplog):
             f"{b}/lig_in_{env}.psf",
         )
         traj.save_dcd(f"{base}/traj.dcd")
-        l_charmm = f._evaluated_e_on_all_snapshots_CHARMM(traj, idx + 1, env)
+        l_charmm = f._evaluate_e_on_all_snapshots_CHARMM(traj, idx + 1, env)
         l_openMM = f._evaluated_e_on_all_snapshots_openMM(traj, idx + 1, env)
 
         assert len(l_charmm) == len(l_openMM)

--- a/transformato/tests/test_switching.py
+++ b/transformato/tests/test_switching.py
@@ -41,7 +41,7 @@ def test_run_2OJ9_tautomer_pair_vfswitch(caplog):
     )
     # save dcd in freshly generated system
     traj.save_dcd(f"{system_path}/traj.dcd", force_overwrite=True)
-    l_charmm = f._evaluated_e_on_all_snapshots_CHARMM(traj, 1, env)
+    l_charmm = f._evaluate_e_on_all_snapshots_CHARMM(traj, 1, env)
     l_openMM = f._evaluated_e_on_all_snapshots_openMM(traj, 1, env)
     assert len(l_charmm) == len(l_openMM)
     s = abs(np.array(l_charmm) - np.array(l_openMM))
@@ -85,7 +85,7 @@ def test_run_2OJ9_tautomer_pair_vswitch(caplog):
     )
     # save dcd in freshly generated system
     traj.save_dcd(f"{system_path}/traj.dcd", force_overwrite=True)
-    l_charmm = f._evaluated_e_on_all_snapshots_CHARMM(traj, 1, env)
+    l_charmm = f._evaluate_e_on_all_snapshots_CHARMM(traj, 1, env)
     l_openMM = f._evaluated_e_on_all_snapshots_openMM(traj, 1, env)
     assert len(l_charmm) == len(l_openMM)
     assert np.isclose(l_charmm[0], -16445.54761007052, atol=1e-4)
@@ -98,4 +98,3 @@ def test_run_2OJ9_tautomer_pair_vswitch(caplog):
     for e_charmm, e_openMM in zip(l_charmm, l_openMM):
         print(f"{e_charmm}, {e_openMM}: {e_charmm - e_openMM}")
         assert np.isclose(e_charmm, e_openMM, atol=2.2)
-

--- a/transformato/tests/test_testsystems.py
+++ b/transformato/tests/test_testsystems.py
@@ -40,7 +40,7 @@ def test_rbfe_mutate_2oj9():
     configuration = load_config_yaml(
         config=conf_path, input_dir="data/", output_dir="."
     )
-    # check_platform(configuration)
+    # change_platform(configuration)
 
     s1 = SystemStructure(configuration, "structure1")
     s2 = SystemStructure(configuration, "structure2")

--- a/transformato/testsystems.py
+++ b/transformato/testsystems.py
@@ -4,14 +4,14 @@ import transformato
 from transformato.mutate import ProposeMutationRoute
 from transformato.state import IntermediateStateFactory
 from transformato.system import SystemStructure
-from transformato.constants import check_platform
+from transformato.constants import change_platform
 
 transformato_systems_dir = "/home/mwieder/Work/Projects/transformato-systems/"
 
 
 def mutate_methane_to_methane_cc(configuration: dict):
 
-    check_platform(configuration)
+    change_platform(configuration)
 
     s1 = SystemStructure(configuration, "structure1")
     s2 = SystemStructure(configuration, "structure2")
@@ -52,7 +52,7 @@ def mutate_methane_to_methane_cc(configuration: dict):
 
 def testing_mutate_toluene_to_methane_cc(configuration: dict):
 
-    check_platform(configuration)
+    change_platform(configuration)
 
     s1 = SystemStructure(configuration, "structure1")
     s2 = SystemStructure(configuration, "structure2")
@@ -124,7 +124,7 @@ def testing_mutate_toluene_to_methane_cc(configuration: dict):
 
 def mutate_toluene_to_methane_cc(configuration: dict):
 
-    check_platform(configuration)
+    change_platform(configuration)
     s1 = SystemStructure(configuration, "structure1")
     s2 = SystemStructure(configuration, "structure2")
 
@@ -235,7 +235,7 @@ def mutate_toluene_to_methane_cc(configuration: dict):
 
 def mutate_ethane_to_methane_cc(configuration: dict):
 
-    check_platform(configuration)
+    change_platform(configuration)
 
     s1 = SystemStructure(configuration, "structure1")
     s2 = SystemStructure(configuration, "structure2")
@@ -296,7 +296,7 @@ def mutate_ethane_to_methane_cc(configuration: dict):
 
 def mutate_methanol_to_methane_cc(configuration: dict):
 
-    check_platform(configuration)
+    change_platform(configuration)
 
     s1 = SystemStructure(configuration, "structure1")
     s2 = SystemStructure(configuration, "structure2")
@@ -392,7 +392,7 @@ def mutate_methanol_to_methane_cc(configuration: dict):
 
 def mutate_ethane_to_methanol_cc(configuration: dict):  # not a loeffler system
 
-    check_platform(configuration)
+    change_platform(configuration)
 
     s1 = SystemStructure(configuration, "structure1")
     s2 = SystemStructure(configuration, "structure2")
@@ -452,7 +452,7 @@ def mutate_ethane_to_methanol_cc(configuration: dict):  # not a loeffler system
 
 def mutate_7_CPI_to_2_CPI_cc(configuration: dict):  # will be tested later on
 
-    check_platform(configuration)
+    change_platform(configuration)
 
     s1 = SystemStructure(configuration, "structure1")
     s2 = SystemStructure(configuration, "structure2")
@@ -525,7 +525,7 @@ def mutate_7_CPI_to_2_CPI_cc(configuration: dict):  # will be tested later on
 
 def mutate_2_CPI_to_7_CPI_cc(configuration: dict):  # will be tested later on
 
-    check_platform(configuration)
+    change_platform(configuration)
 
     s1 = SystemStructure(configuration, "structure1")
     s2 = SystemStructure(configuration, "structure2")
@@ -608,7 +608,7 @@ def mutate_2_CPI_to_7_CPI_cc(configuration: dict):  # will be tested later on
 
 def mutate_2_methylfuran_to_methane_cc(configuration: dict):
 
-    check_platform(configuration)
+    change_platform(configuration)
 
     s1 = SystemStructure(configuration, "structure1")
     s2 = SystemStructure(configuration, "structure2")
@@ -711,7 +711,7 @@ def mutate_2_methylfuran_to_methane_cc(configuration: dict):
 
 def mutate_neopentane_to_methane_cc(configuration: dict):
 
-    check_platform(configuration)
+    change_platform(configuration)
 
     s1 = SystemStructure(configuration, "structure1")
     s2 = SystemStructure(configuration, "structure2")
@@ -810,7 +810,7 @@ def mutate_neopentane_to_methane_cc(configuration: dict):
 
 def mutate_2_methylindole_to_methane_cc(configuration: dict):
 
-    check_platform(configuration)
+    change_platform(configuration)
 
     s1 = SystemStructure(configuration, "structure1")
     s2 = SystemStructure(configuration, "structure2")


### PR DESCRIPTION
## Description
Using the multiprocessing library we load the trajectory in each process even though we don't change the data. It would be much better to define a shared memory object that contains the coordinates.

## Todos
  - [ x] put coordinates in shared memory object
  - [ x]  prepare the postprocessing module to work nicely with these changes
  - [ x] make things faster

## Status
- [ x] Ready to go