### PR TITLE
Merge pull request #29 from wiederm/JohannesKarwou-patch-1

### DIFF
--- a/transformato/analysis.py
+++ b/transformato/analysis.py
@@ -350,9 +350,9 @@ class FreeEnergyCalculator(object):
             simulation = self._generate_openMM_system(env=env, lambda_state=lambda_state)
 
             # calc energy
-            energies = self._evaluate_e_with_openMM(
+            energies.extend(self._evaluate_e_with_openMM(
                 xyz_array, simulation, env, unitcell_lengths
-            )
+            ))
             traj.close()
         return np.array(energies)
 
@@ -487,17 +487,20 @@ class FreeEnergyCalculator(object):
         logger.debug("#######################################")
         u_kn_ = copy.deepcopy(u_kn)
         start = 0
-        for d in range(u_kn.shape[0] - 1):
+        for lamb in range(u_kn.shape[0] - 1):
             logger.debug(self.N_k)
-            logger.debug(f"{d}->{d+1} [kT]")
-            nr_of_snapshots = self.N_k[env][d] + self.N_k[env][d + 1]
-            u_kn_ = u_kn[d : d + 2 :, start : start + nr_of_snapshots]
+            logger.debug(f"{lamb }->{lamb +1} [kT]")
+            nr_of_snapshots = self.N_k[env][lamb ] + self.N_k[env][lamb  + 1]
+            u_kn_ = u_kn[lamb  : lamb  + 2 :, start : start + nr_of_snapshots]
+            print(u_kn.shape())
+            
 
-            m = mbar.MBAR(u_kn_, self.N_k[env][d : d + 2])
+            m = mbar.MBAR(u_kn_, self.N_k[env][lamb  : lamb  + 2])
             logger.debug(m.getFreeEnergyDifferences(return_dict=True)["Delta_f"][0, 1])
             logger.debug(m.getFreeEnergyDifferences(return_dict=True)["dDelta_f"][0, 1])
 
-            start += self.N_k[env][d]
+            start += self.N_k[env][lamb]
+
 
         logger.debug("#######################################")
         return mbar.MBAR(u_kn, self.N_k[env], initialize="BAR", verbose=True)

--- a/transformato/tests/test_misc.py
+++ b/transformato/tests/test_misc.py
@@ -2,12 +2,30 @@
 Unit and regression test for the transformato package.
 """
 
-import logging
 from transformato.utils import load_config_yaml
 from transformato.analysis import return_reduced_potential
-import pytest
 from simtk import unit
 import numpy as np
+
+def test_read_psf_with_openMM():
+    from simtk.openmm.app.charmmpsffile import CharmmPsfFile
+    system_name = '2OJ9-original'
+    # read psf for protein/ligand system
+    f = CharmmPsfFile(f'data/{system_name}/complex/openmm/step3_input.psf')
+    # read psf for ligand system
+    f = CharmmPsfFile(f'data/{system_name}/waterbox/openmm/step3_input.psf')
+
+    system_name = '2OJ9-tautomer'
+    # read psf for protein/ligand system
+    f = CharmmPsfFile(f'data/{system_name}/complex/openmm/step3_input.psf')
+    # read psf for ligand system
+    f = CharmmPsfFile(f'data/{system_name}/waterbox/openmm/step3_input.psf')
+
+    system_name = '2OJ9-original-2OJ9-tautomer-rbfe'
+    # read psf for protein/ligand system
+    f = CharmmPsfFile(f'data/{system_name}/2OJ9-original/intst1/lig_in_waterbox.psf')
+    # read psf for ligand system
+    f = CharmmPsfFile(f'data/{system_name}/2OJ9-original/intst1/lig_in_complex.psf')
 
 
 def test_reduced_energy():
@@ -76,16 +94,3 @@ def test_scaling():
         print(f"{i}:{f}")
 
     print("##########################")
-
-
-def test_old_scaling():
-    import numpy as np
-
-    for i in np.linspace(1, 0, 11):
-        f = 1 - (1 - i) * 2
-        print(f"{i}:{f}")
-    print("##########################")
-
-    for i in np.linspace(1, 0, 11):
-        f = 1 - (1 - (1 - i)) * 2
-        print(f"{i}:{f}")

--- a/transformato/tests/test_postprocessing.py
+++ b/transformato/tests/test_postprocessing.py
@@ -28,13 +28,19 @@ def postprocessing(
     max_snapshots: int = 300,
     show_summary: bool = False,
     different_path_for_dcd: str = "",
-    only_vacuum: bool = False,
+    only_single_state:str = '',
 ):
     from transformato import FreeEnergyCalculator
 
     f = FreeEnergyCalculator(configuration, name)
-    if only_vacuum:
+    if only_single_state == 'vacuum':
         f.envs = ["vacuum"]
+    elif only_single_state == 'waterbox':
+        f.envs = ["waterbox"]
+    elif only_single_state == 'complex':
+        f.envs = ["complex"]
+    else:
+        print(f'Both states are considered')
 
     if different_path_for_dcd:
         # this is needed if the trajectories are stored at a different location than the
@@ -47,7 +53,7 @@ def postprocessing(
         f.load_trajs(nr_of_max_snapshots=max_snapshots)
 
     f.calculate_dG_to_common_core(engine=engine)
-    if only_vacuum:
+    if only_single_state:
         return -1, -1, f
     else:
         ddG, dddG = f.end_state_free_energy_difference
@@ -469,6 +475,30 @@ def test_2oj9_calculate_rbfe_with_openMM():
     # 2OJ9-original to tautomer common core
     ddG_openMM, dddG, f_openMM = postprocessing(
         configuration, name="2OJ9-original", engine="openMM", max_snapshots=200
+    )
+
+
+@pytest.mark.system_2oj9
+@pytest.mark.slowtest
+@pytest.mark.skipif(
+    os.environ.get("TRAVIS", None) == "true", reason="Skip slow test on travis."
+)
+def test_2oj9_calculate_rbfe_with_openMM_only_complex():
+
+    initialize_NUM_PROC(1)
+
+    conf = "transformato/tests/config/test-2oj9-tautomer-pair-rbfe.yaml"
+    configuration = load_config_yaml(
+        config=conf, input_dir="data/", output_dir="data"
+    )  # NOTE: for preprocessing input_dir is the output dir
+
+    # 2OJ9-original to tautomer common core
+    ddG_openMM, dddG, f_openMM = postprocessing(
+        configuration, 
+        name="2OJ9-original", 
+        engine="openMM", 
+        max_snapshots=10_000, 
+        only_single_state='complex'
     )
 
 
@@ -1007,3 +1037,25 @@ def test_postprocessing_thinning():
     print(f.snapshots["vacuum"])
     assert len(f.snapshots["vacuum"]) == 1950
     assert len(f.snapshots["waterbox"]) == 1950
+
+def test_lazy_eval():
+    import mdtraj as md
+    base_path = f"data/2OJ9-original-2OJ9-tautomer-rsfe/2OJ9-original/intst1/"
+    dcd_path = f"{base_path}/lig_in_waterbox.dcd"
+    psf_file = f"{base_path}/lig_in_waterbox.psf"
+    traj = md.load(
+        f"{dcd_path}",
+        top=f"{psf_file}",
+    )
+
+    with md.open(dcd_path) as f:
+        f.seek(10)
+        xyz, unitcell_lengths, unitcell_angles = f.read()
+
+    assert (xyz.shape) == (190, 2530, 3)
+    assert len(xyz) == 190
+
+    print(unitcell_lengths[0])
+    print(len(unitcell_lengths))
+    assert len(unitcell_lengths) == 190
+    print(unitcell_angles[0])


### PR DESCRIPTION
## Description
Lazy evaluation of trajectories in postprocessing
NOTE: This works only for single processor runs for now! I don't see a reason why it shouldn't play nice with the multiprocessing library, but not yet implemented.

## Todos
  - [x] Lazy eval for trajs for openMM
  - [ ] make sure it plays nicely with CHARMM

## Questions
- [ ] Some reorganization, more tests needed

## Status
- [ ] Ready to go