### PR TITLE
Change handling of toppar directory

### DIFF
--- a/transformato/state.py
+++ b/transformato/state.py
@@ -491,7 +491,8 @@ with open(file_name + '_system.xml','w') as outfile:
 
         # copy central toppar folder
         toppar_dir = get_toppar_dir()
-        toppar_source = f"{toppar_dir}"
+        #toppar_source = f"{toppar_dir}"
+        toppar_source = f"{basedir}/waterbox/toppar"
         toppar_target = f"{intermediate_state_file_path}/toppar"
         shutil.copytree(toppar_source, toppar_target)
 

--- a/transformato/system.py
+++ b/transformato/system.py
@@ -148,7 +148,7 @@ class SystemStructure(object):
                 logger.info(f"CGenFF version: {cgenff}")
                 cgenff_version = re.findall("\d+\.\d+", cgenff)[0]
                 self.cgenff_version = float(cgenff_version)
-
+        toppar_dir = f"{charmm_gui_env}/toppar"
         parameter_files += (f"{toppar_dir}/top_all36_prot.rtf",)
         parameter_files += (f"{toppar_dir}/par_all36m_prot.prm",)
         parameter_files += (f"{toppar_dir}/par_all36_na.prm",)


### PR DESCRIPTION
## Description
The latest version of the toppar directory (provided by CHARMM-GUI) should be used. Furthermore, we need to handle the toppar directory more efficiently. 