### PR TITLE
adding toppar_all36_moreions to the toppar.str

### DIFF
--- a/transformato/system.py
+++ b/transformato/system.py
@@ -189,6 +189,7 @@ class SystemStructure(object):
         parameter_files += (f"{toppar_dir}/par_all36_lipid.prm",)
         parameter_files += (f"{toppar_dir}/top_all36_lipid.rtf",)
         parameter_files += (f"{toppar_dir}/toppar_water_ions.str",)
+        parameter_files += (f"{toppar_dir}/toppar_all36_moreions.str",)
         parameter_files += (
             f"{toppar_dir}/toppar_all36_prot_na_combined.str",
         )  # if modified aminoacids are needed


### PR DESCRIPTION
As suggested by @szaand in https://github.com/wiederm/transformato/issues/67, I added the ```toppar_all36_moreions.str```, so that it is now included in the ```toppar.str``` file. 