### PR TITLE
adding moreions file to toppar.str

### DIFF
--- a/transformato/system.py
+++ b/transformato/system.py
@@ -192,7 +192,8 @@ class SystemStructure(object):
         parameter_files += (
             f"{toppar_dir}/toppar_all36_prot_na_combined.str",
         )  # if modified aminoacids are needed
-
+        if os.path.isfile(f"{toppar_dir}/toppar_all36_moreions.str"):
+            parameter_files += (f"{toppar_dir}/toppar_all36_moreions.str",)
         # set up parameter objec
         parameter = pm.charmm.CharmmParameterSet(*parameter_files)
         return parameter


### PR DESCRIPTION
As suggested by @szaand in https://github.com/wiederm/transformato/issues/67, I added the ```toppar_all36_moreions.str```, so that it is now included in the ```toppar.str``` file. 