### PR TITLE
using openmmtools for flat bottom restraints

### DIFF
--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -5,6 +5,7 @@ channels:
 dependencies:
   # Base depends
   - openmm==7.5.1
+  - openmmtools
   - numpy
   - ipython
   - pymbar

--- a/transformato/restraints.py
+++ b/transformato/restraints.py
@@ -121,7 +121,7 @@ class Restraint:
             self.force.addBond(
                 [0, 1], [self.force_constant, self.initial_distance / 10]
             )
-
+            
             logger.info(
                 f"""Restraint force (centroid/bonded, shape is {self.shape}, initial distance: {self.initial_distance}, k={self.force_constant}"""
             )
@@ -135,7 +135,7 @@ class Restraint:
                 restrained_atom_indices1=self.g1_openmm,
                 restrained_atom_indices2=self.g2_openmm,
             )
-
+            
             self.force.setUsesPeriodicBoundaryConditions(periodic=True)
 
             logger.info(

--- a/transformato/restraints.py
+++ b/transformato/restraints.py
@@ -126,25 +126,20 @@ class Restraint:
                 f"""Restraint force (centroid/bonded, shape is {self.shape}, initial distance: {self.initial_distance}, k={self.force_constant}"""
             )
         elif self.shape == "flatbottom":
-            # create force with flat-bottom potential
+            # create force with flat-bottom potential using openmmtools
+            from openmmtools.forces import FlatBottomRestraintForce
 
-            self.force = CustomCentroidBondForce(
-                2, "step(abs(distance(g1,g2)-r0)-w)*k*(distance(g1,g2)-r0)^2"
+            self.force = FlatBottomRestraintForce(
+                spring_constant=self.force_constant,
+                well_radius=self.initial_distance * angstrom,
+                restrained_atom_indices1=self.g1_openmm,
+                restrained_atom_indices2=self.g2_openmm,
             )
 
-            # Native openMM step function. Should be 0 for x<0 and 1 for x>=0.
-            self.force.addPerBondParameter("k")
-            self.force.addPerBondParameter("r0")
-            self.force.addPerBondParameter("w")
-            self.force.addGroup(self.g1_openmm)
-            self.force.addGroup(self.g2_openmm)
-
-            self.force.addBond(
-                [0, 1], [self.force_constant, self.initial_distance / 10, self.wellsize]
-            )
+            self.force.setUsesPeriodicBoundaryConditions(periodic=True)
 
             logger.info(
-                f"Restraint force (centroid/bonded, shape is {self.shape}, initial distance: {self.initial_distance}, k={self.force_constant} wellsize={self.wellsize}"
+                f"Restraint force (centroid/bonded, shape is {self.shape}, initial distance: {self.initial_distance}, k={self.force_constant} the finall parameters are: {self.force.getBondParameters(0)}"
             )
 
         else:

--- a/transformato/tests/test_restraints.py
+++ b/transformato/tests/test_restraints.py
@@ -248,13 +248,16 @@ def test_integration():
     for i,f in enumerate(system.getForces()):
         if isinstance(f,CustomCentroidBondForce):
             logger.debug(f.getBondParameters(0))
-            if f.getNumPerBondParameters()==2: # harmonic shape
+            if f.getPerBondParameterName(0)=="k": # harmonic shape. openmmTools calls theirs "K"
                 f.setBondParameters(0,[0,1],[25,5])
             else: # flatbottom shape:
-                f.setBondParameters(0,[0,1],[25,5,0.1])
+                f.setBondParameters(0,[0,1],[250,0.01])
             f.updateParametersInContext(simulation.context)
     
-   
+    for i,f in enumerate(system.getForces()):
+        if isinstance(f,CustomCentroidBondForce):
+            logger.debug(f.getBondParameters(0))
+
     temp_results=[]
     simulation.step(10)
     for i,f in enumerate(system.getForces()):


### PR DESCRIPTION
We can use the flat bottom restraints from ([openmmtools](https://openmmtools.readthedocs.io/en/latest/api/generated/openmmtools.forces.FlatBottomRestraintForce.html#openmmtools.forces.FlatBottomRestraintForce)). In this case the `well_radius` will correspond to the `initial_distance` one wants to keep. If using them as suggested in the openmmtools, it would mean, that the restraints start to have an effect after exceeding this initial distance but not when the distance gets closer. This should be fine in my opinion since there should be Coulomb repulsion if distances get to close.