### PR TITLE
Test fixes to openmmtools flatbottoms

### DIFF
--- a/transformato/restraints.py
+++ b/transformato/restraints.py
@@ -121,7 +121,7 @@ class Restraint:
             self.force.addBond(
                 [0, 1], [self.force_constant, self.initial_distance / 10]
             )
-
+            
             logger.info(
                 f"""Restraint force (centroid/bonded, shape is {self.shape}, initial distance: {self.initial_distance}, k={self.force_constant}"""
             )
@@ -135,7 +135,7 @@ class Restraint:
                 restrained_atom_indices1=self.g1_openmm,
                 restrained_atom_indices2=self.g2_openmm,
             )
-
+            
             self.force.setUsesPeriodicBoundaryConditions(periodic=True)
 
             logger.info(

--- a/transformato/tests/test_restraints.py
+++ b/transformato/tests/test_restraints.py
@@ -248,13 +248,16 @@ def test_integration():
     for i,f in enumerate(system.getForces()):
         if isinstance(f,CustomCentroidBondForce):
             logger.debug(f.getBondParameters(0))
-            if f.getNumPerBondParameters()==2: # harmonic shape
+            if f.getPerBondParameterName(0)=="k": # harmonic shape. openmmTools calls theirs "K"
                 f.setBondParameters(0,[0,1],[25,5])
             else: # flatbottom shape:
-                f.setBondParameters(0,[0,1],[25,5,0.1])
+                f.setBondParameters(0,[0,1],[250,0.01])
             f.updateParametersInContext(simulation.context)
     
-   
+    for i,f in enumerate(system.getForces()):
+        if isinstance(f,CustomCentroidBondForce):
+            logger.debug(f.getBondParameters(0))
+
     temp_results=[]
     simulation.step(10)
     for i,f in enumerate(system.getForces()):


### PR DESCRIPTION
Fixes parameter issues encountered by tests, as outlined in PR #73. Differentiation now happens with name of spring parameter.