### PR TITLE
Update .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 # Apply override to all files in the directory (source: https://github.com/github/linguist/blob/master/docs/overrides.md)
 data/** linguist-vendored
+transformato/toppar/** linguist-vendored


### PR DESCRIPTION
Exclude ``toppar`` directory from the linguist vendor of github, so that language on github won't show 88.4% Rich Text format (which comes from the ff files)