### PR TITLE
save endstate results as pickle

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,5 +1,3 @@
-enhancement:
-- transformato/**/*
 asfe:
 - transformato/annihilation.py
 restraints:
@@ -8,3 +6,6 @@ charmm:
 - transformato/charmm_factory.py
 analysis:
 - transformato/analysis.py
+endstate_correction:
+- transformato/bin/perform_correction.py
+- transformato/bin/slurm_switching.sh

--- a/transformato/bin/perform_correction.py
+++ b/transformato/bin/perform_correction.py
@@ -11,6 +11,7 @@ from openmm.app import (
 from endstate_correction.analysis import plot_endstate_correction_results
 from endstate_correction.protocol import perform_endstate_correction, Protocol
 import mdtraj
+import pickle
 from openmm import unit
 
 
@@ -79,6 +80,10 @@ for env in ["waterbox", "vacuum"]:
     )
 
     r = perform_endstate_correction(fep_protocoll)
+    
+    with open(f"results_{system_name}.pickle", "wb") as file:
+        pickle.dump(r, file)
+        
     plot_endstate_correction_results(
         system_name, r, f"results_neq_unidirectional_{env}.png"
     )


### PR DESCRIPTION
As discussed with @saratk1 today, it would be helpful to save the work values to search for errors if something goes wrong. So far I only managed to save it as a `pickle` file. But I think for now that would be sufficient.