### PR TITLE
No multiple restraints on atom & switch to single topology for restraint generation

### DIFF
--- a/transformato/restraints.py
+++ b/transformato/restraints.py
@@ -429,6 +429,19 @@ def create_restraints_from_config(configuration, pdbpath):
                     **restraint_args,
                 )
             )
+        
+        # At this point only automatic ex-restraints exist
+        # check for duplicates in the ligand group g1
+
+        all_restraint_atoms=restraints[0].g1
+        for restraint in restraints[1:-1]:
+            all_restraint_atoms+=restraint.g1
+        logger.info(f"All restraint atoms: {[atom.name for atom in all_restraint_atoms]}")
+        duplicate_restraint_atoms=set([atom for atom in all_restraint_atoms if all_restraint_atoms.ix.tolist().count(atom.ix)>1])
+        logger.info(f"list: {all_restraint_atoms.ix.tolist()}")
+        logger.info(f"Duplicate restraint atoms: {duplicate_restraint_atoms}")
+
+
 
     if "manual" in restraint_command_string:
         logger.debug("generating manual selections")

--- a/transformato/tests/test_restraints.py
+++ b/transformato/tests/test_restraints.py
@@ -23,6 +23,7 @@ import transformato.restraints as tfrs
 import transformato.utils as tfut
 import yaml
 from transformato_testsystems.testsystems import get_testsystems_dir
+import MDAnalysis
 
 PATH_2OJ9 = f"{get_testsystems_dir()}/2OJ9-original/complex/openmm/step3_input.pdb"
 PATH_2OJ9_DIR = f"{get_testsystems_dir()}/2OJ9-original/complex/openmm/"
@@ -54,13 +55,13 @@ def test_create_restraints_from_config():
 def test_restraints():
 
     testrestraint = tfrs.Restraint(
-        "resname BMI and type C", "protein and name CA", PATH_2OJ9, 14
+        "resname BMI and type C", "protein and name CA", MDAnalysis.Universe(PATH_2OJ9), 14
     )
 
     testrestraint_fb = tfrs.Restraint(
         "resname BMI and type C",
         "protein and name CA",
-        PATH_2OJ9,
+        MDAnalysis.Universe(PATH_2OJ9),
         14,
         shape="flatbottom",
         wellsize=0.12,

--- a/transformato/tests/test_restraints.py
+++ b/transformato/tests/test_restraints.py
@@ -44,6 +44,10 @@ def test_create_restraints_from_config():
         config = yaml.safe_load(stream)
 
     assert type(config) == dict  # checks if config yaml is properly loaded
+
+    # Modify the imported config to check duplicate restraint atom handling
+    config["simulation"]["restraints"]="auto k=100 scaling extremities=5 manual"
+    
     restraints = tfrs.create_restraints_from_config(config, PATH_2OJ9)
     assert type(restraints) == list
     for restraint in restraints:

--- a/transformato/tests/test_restraints.py
+++ b/transformato/tests/test_restraints.py
@@ -172,6 +172,7 @@ def test_integration():
 
     prop = dict()
     pdbpath = PATH_2OJ9
+    universe = MDAnalysis.Universe(PATH_2OJ9)
     with open(
         f"{get_testsystems_dir()}/config/test-2oj9-restraints.yaml", "r"
     ) as stream:
@@ -194,9 +195,9 @@ def test_integration():
 
     # Test an additional, simple restraint
     logger.debug("generating simple selection")
-    selstr = tfrs.generate_simple_selection(configuration, pdbpath)
+    selstr = tfrs.generate_simple_selection(configuration)
     tlc = configuration["system"]["structure"]["tlc"]
-    restraintList.append(tfrs.Restraint(f"resname {tlc} and type C", selstr, pdbpath))
+    restraintList.append(tfrs.Restraint(f"resname {tlc} and type C", selstr, universe))
 
     logger.debug(
         "****************** ALL RESTRAINTS CREATED SUCCESSFULLY ***************************"


### PR DESCRIPTION
## Description

- Fixes the issues outlined in #102 with regard to individual atoms being part of multiple automatic restraint groups
 `restraints.py` now checks for duplicates in the ligand restraint groups (`Restraint.g1`) when initializing the automatic extremity restraints. If duplicates are found, the atom is assigned to the restraint with its core closest to the atom position. The atom is deleted from all other restraints.

- Significant memory management improvements
Previously, each restraint initialized its own `MDAnalysis.Universe` instance. This was extremely stupid. Now, a shared instance is used by all restraints, significantly improving memory usage and performance. (-6.8s for a 5-extremity 2OJ9 on an admittedly rather slow VM)

- Tests adapted for new single-topology approach and duplicates


## Status
- Local tests with `-m restraints` go through. No external API changes, so there should be not problem with CI or the other tests, but it might be worth running them just in case.