### PR TITLE
updated parmed

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -32,11 +32,24 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        # os: [macOS-latest, ubuntu-latest]
         os: [ubuntu-latest]
         python-version: [3.9]
+        include:
+          - os: ubuntu-latest
+            label: linux-64
+            # prefix: /usr/share/miniconda3/envs/openmm7.6
+            environment-file: devtools/conda-envs/fep_env.yaml
+            miniforge-variant: Mambaforge
+            miniforge-version: 4.9.2-4
+          #- os: macos-latest
+          #  label: osx-64
+          #  # prefix: /Users/runner/miniconda3/envs/openmm7.6
+          #  environment-file: devtools/conda-envs/openmm7.6.yaml
+          #  miniforge-variant: Mambaforge-pypy3
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
 
     - name: Additional info about the build
       shell: bash
@@ -50,7 +63,7 @@ jobs:
       
     - name: Make Cache (no worflow_dispatch)
       if: ${{ github.event_name != 'workflow_dispatch' }}
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/conda_pkgs_dir # ${{ matrix.prefix }}
         # Increase the last number (0) to reset cache manually
@@ -70,12 +83,17 @@ jobs:
     - uses: conda-incubator/setup-miniconda@v2
       with:
         python-version: ${{ matrix.python-version }}
-        environment-file: devtools/conda-envs/fep_env.yaml
-
+        condarc-file: ${{ matrix.condarc-file }}
+        environment-file: ${{ matrix.environment-file }}
+        miniforge-variant: ${{ matrix.miniforge-variant }}
+        miniforge-version: ${{ matrix.miniforge-version }}
+        use-mamba: true
+        # mamba-version: "*"
+        # environment-file: devtools/conda-envs/fep_env.yaml
         channels: conda-forge,defaults
-
-        activate-environment: test
-        auto-update-conda: false
+        # channel-priority: true
+        activate-environment: fep
+        #auto-update-conda: false
         auto-activate-base: false
         #show-channel-urls: true
         use-only-tar-bz2: true # IMPORTANT: This needs to be set for caching to work properly!
@@ -89,7 +107,11 @@ jobs:
       shell: bash -l {0}
       run: |
         python -m pip install . --no-deps
+        conda info
         conda list
+        conda config --show-sources
+        conda config --show
+        printenv | sort
 
 
     - name: Run tests

--- a/devtools/conda-envs/fep_env.yaml
+++ b/devtools/conda-envs/fep_env.yaml
@@ -10,7 +10,7 @@ dependencies:
   - ipython
   - pymbar=3
   - rdkit
-  - parmed=4
+  - parmed
   - pyyaml
   - mdtraj
   - mdanalysis

--- a/devtools/conda-envs/fep_env.yaml
+++ b/devtools/conda-envs/fep_env.yaml
@@ -10,7 +10,7 @@ dependencies:
   - ipython
   - pymbar=3
   - rdkit
-  - parmed
+  - parmed=4
   - pyyaml
   - mdtraj
   - mdanalysis

--- a/devtools/conda-envs/fep_env.yaml
+++ b/devtools/conda-envs/fep_env.yaml
@@ -17,6 +17,7 @@ dependencies:
   - matplotlib
   - networkx
   - tqdm
+  - pip
   - seaborn
     # Testing
   - pytest
@@ -24,4 +25,5 @@ dependencies:
   - codecov
   - pip:
     - git+https://github.com/wiederm/tf_routes.git
+    - git+https://github.com/ParmEd/ParmEd.git
     - git+https://github.com/wiederm/transformato_testsystems.git

--- a/transformato/tests/test_system_setup.py
+++ b/transformato/tests/test_system_setup.py
@@ -232,12 +232,6 @@ def generate_openMM_system_using_cgui_scripts(base: str):
     return system, psf
 
 
-@pytest.mark.rbfe
-@pytest.mark.requires_parmed_supporting_lp
-@pytest.mark.skipif(
-    os.getenv("CI") == "true",
-    reason="Skipping tests that cannot pass in github actions",
-)
 def test_lonepairs_in_dummy_region():
     configuration = load_config_yaml(
         config=f"{get_testsystems_dir()}/config/jnk1-17124-18631.yaml",
@@ -267,12 +261,6 @@ def test_lonepairs_in_dummy_region():
     assert s1_to_s2.dummy_region_cc2.connected_dummy_regions == [[39], [40]]
 
 
-@pytest.mark.rbfe
-@pytest.mark.requires_parmed_supporting_lp
-@pytest.mark.skipif(
-    os.getenv("CI") == "true",
-    reason="Skipping tests that cannot pass in github actions",
-)
 def test_lonepairs_in_common_core():
     configuration = load_config_yaml(
         config=f"{get_testsystems_dir()}/config/tyk2-ejm_45_ejm_42.yaml",


### PR DESCRIPTION
`parmed` has now a new version, so it is not necessary to exclude these two tests which were relying on a special forked `parmed` version which we couldn't provide in the `Github CI`.
I also updated our CI from using `conda` to `mamba` which makes everything a lot faster