### PR TITLE
adapting name for checking torison atoms

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,6 @@ transformato can be easily installed from conda-forge:
 ```
 conda install transformato -c conda-forge
 ```
-:warning: **When installing from conda-forge, lone-pairs are not supported!** :bangbang:
-
-for lone-pair support install transformato directly from github following this [instructions](https://wiederm.github.io/transformato/Installation.html)
 
 ## Usage
 

--- a/transformato/mutate.py
+++ b/transformato/mutate.py
@@ -1729,7 +1729,7 @@ class CommonCoreTransformation(object):
                             original_torsion.atom1.type,
                             original_torsion.atom2.type,
                             original_torsion.atom3.type,
-                            original_torsion.atom3.type,
+                            original_torsion.atom4.type,
                         ]
                     ) == sorted(
                         [


### PR DESCRIPTION
I'm more and more convinced that this is a bug https://github.com/wiederm/transformato/issues/105, which we should fix. I think the solution is very trivial. I will see if I can add some testcases. 